### PR TITLE
Add checker_extensions config

### DIFF
--- a/SyntaxChecker.py
+++ b/SyntaxChecker.py
@@ -1,44 +1,56 @@
 import sublime, sublime_plugin
 
+def has_ext(name, exts):
+    if not isinstance(exts, list):
+        exts = [exts]
+    return any(name.endswith(ext) for ext in exts)
+
 class SyntaxChecker(sublime_plugin.EventListener):
-	def on_post_save(self, view):
-		if view.file_name()[-3:] == '.rb':
-			view.window().run_command("ruby_checker", {"saving": True})
-		elif view.file_name()[-3:] == '.pl':
-			view.window().run_command("perl_checker", {"saving": True})
-		elif view.file_name()[-4:] == '.php' or view.file_name()[-8:] == '.php.inc':
-			view.window().run_command("php_checker", {"saving": True})
-		elif view.file_name()[-4:] == '.xml':
-			view.window().run_command("xml_checker", {"saving": True})
+    def on_post_save(self, view):
+        global_settings = sublime.load_settings(__name__ + '.sublime-settings')
+        exts = view.settings().get('checker_extensions', global_settings.get('checker_extensions', {}))
+        exts['ruby'] = exts['ruby'] or ['.rb']
+        exts['xml'] = exts['xml'] or ['.xml']
+        exts['perl'] = exts['perl'] or ['.pl']
+        exts['php'] = exts['php'] or ['.php', '.php.inc']
+        print exts
+
+        name = view.file_name()
+        print name
+        for key in ['ruby', 'perl', 'php', 'xml']:
+            if has_ext(name, exts[key]):
+                print "got it"
+                view.window().run_command(key + "_checker", {"saving": True})
+                break
 
 class RubyCheckerCommand(sublime_plugin.TextCommand):
-	def run(self, edit, saving=False):
-		view = self.view
-		global_settings = sublime.load_settings(__name__ + '.sublime-settings')
-		cmd_setting = 'ruby_syntax_checker_cmd'
-		ruby = view.settings().get(cmd_setting, global_settings.get(cmd_setting))
-		view.window().run_command("exec", {"cmd": [ruby, "-cw", view.file_name()]})
+    def run(self, edit, saving=False):
+        view = self.view
+        global_settings = sublime.load_settings(__name__ + '.sublime-settings')
+        cmd_setting = 'ruby_syntax_checker_cmd'
+        ruby = view.settings().get(cmd_setting, global_settings.get(cmd_setting))
+        view.window().run_command("exec", {"cmd": [ruby, "-cw", view.file_name()]})
 
 class PerlCheckerCommand(sublime_plugin.TextCommand):
-	def run(self, edit, saving=False):
-		view = self.view
-		global_settings = sublime.load_settings(__name__ + '.sublime-settings')
-		cmd_setting = 'perl_syntax_checker_cmd'
-		perl = view.settings().get(cmd_setting, global_settings.get(cmd_setting))
-		view.window().run_command("exec", {"cmd": [perl, "-cw", view.file_name()]})
+    def run(self, edit, saving=False):
+        view = self.view
+        global_settings = sublime.load_settings(__name__ + '.sublime-settings')
+        cmd_setting = 'perl_syntax_checker_cmd'
+        perl = view.settings().get(cmd_setting, global_settings.get(cmd_setting))
+        view.window().run_command("exec", {"cmd": [perl, "-cw", view.file_name()]})
 
 class PhpCheckerCommand(sublime_plugin.TextCommand):
-	def run(self, edit, saving=False):
-		view = self.view
-		global_settings = sublime.load_settings(__name__ + '.sublime-settings')
-		cmd_setting = 'php_syntax_checker_cmd'
-		php = view.settings().get(cmd_setting, global_settings.get(cmd_setting))
-		view.window().run_command("exec", {"cmd": [php, "-l", view.file_name()]})
+    def run(self, edit, saving=False):
+        view = self.view
+        global_settings = sublime.load_settings(__name__ + '.sublime-settings')
+        cmd_setting = 'php_syntax_checker_cmd'
+        php = view.settings().get(cmd_setting, global_settings.get(cmd_setting))
+        view.window().run_command("exec", {"cmd": [php, "-l", view.file_name()]})
 
 class XmlCheckerCommand(sublime_plugin.TextCommand):
-	def run(self, edit, saving=False):
-		view = self.view
-		global_settings = sublime.load_settings(__name__ + '.sublime-settings')
-		cmd_setting = 'xml_syntax_checker_cmd'
-		xml = view.settings().get(cmd_setting, global_settings.get(cmd_setting))
-		view.window().run_command("exec", {"cmd": [xml, "--noout", view.file_name()]})
+    def run(self, edit, saving=False):
+        view = self.view
+        global_settings = sublime.load_settings(__name__ + '.sublime-settings')
+        cmd_setting = 'xml_syntax_checker_cmd'
+        xml = view.settings().get(cmd_setting, global_settings.get(cmd_setting))
+        view.window().run_command("exec", {"cmd": [xml, "--noout", view.file_name()]})

--- a/SyntaxChecker.sublime-settings
+++ b/SyntaxChecker.sublime-settings
@@ -6,7 +6,7 @@
     "perl_syntax_checker_cmd": "perl",
     "php_syntax_checker_cmd": "php",
     "xml_syntax_checker_cmd": "xmllint",
-    "extensions": {
+    "checker_extensions": {
         "ruby": [".rb"],
         "xml": [".xml"],
         "perl": [".pl"],

--- a/SyntaxChecker.sublime-settings
+++ b/SyntaxChecker.sublime-settings
@@ -1,9 +1,15 @@
 /*
-	SyntexChecker default settings
+    SyntexChecker default settings
 */
 {
-	"ruby_syntax_checker_cmd": "ruby",
-	"perl_syntax_checker_cmd": "perl",
-	"php_syntax_checker_cmd": "php",
-	"xml_syntax_checker_cmd": "xmllint"
+    "ruby_syntax_checker_cmd": "ruby",
+    "perl_syntax_checker_cmd": "perl",
+    "php_syntax_checker_cmd": "php",
+    "xml_syntax_checker_cmd": "xmllint",
+    "extensions": {
+        "ruby": [".rb"],
+        "xml": [".xml"],
+        "perl": [".pl"],
+        "php": [".php", ".php.inc"]
+    }
 }


### PR DESCRIPTION
It's very restricting to have the type of syntax checks done tightly bound to the extension; this PR adds a configuration, checker_extensions, which allows you to specify a list of extensions to use for each type. This is very helpful for when you have ASLs under different extensions.
